### PR TITLE
Replace Asana link with Linear in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Linear
 <!-- Replace issue id below or add it in the PR title -->
-Fixes ISSUE_ID_HERE
+Fixes LINEAR_ISSUE_ID
 
 ## What type of PR is this?
 <!-- Check all applicable -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Asana Link
+<!-- Remember to put Linear Issue ID in the PR title -->
 
 ## What type of PR is this?
 <!-- Check all applicable -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-<!-- Remember to put Linear Issue ID in the PR title -->
+## Linear
+<!-- Replace issue id below or add it in the PR title -->
+Fixes ISSUE_ID_HERE
 
 ## What type of PR is this?
 <!-- Check all applicable -->


### PR DESCRIPTION
Remove Asana link from PR template as it's no longer relevant after moving to Linear.

Add a reminder to put issue ID in the title or use a [magic word](https://linear.app/docs/github?tabs=b5eb539099f9#link-prs) (`Fixes <issue id>`) to have the PR be auto linked in Linear.