### PR TITLE
Replace "Fixes" with "Contributes to" in PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 ## Linear
-<!-- Replace issue id below or add it in the PR title -->
-Fixes LINEAR_ISSUE_ID
+<!--
+  Replace issue id below or add it in the PR title,
+  you can also replace "Contributes to" with the following keywords
+  "Completes" or "Fixes" to automatically move the issue to done on merge
+-->
+Contributes to LINEAR_ISSUE_ID
 
 ## What type of PR is this?
 <!-- Check all applicable -->


### PR DESCRIPTION
We noticed that a lot of our tasks in Linear accidentally got closed when we're working on PRs (that includes people in our team that do not work with Graphite). This PR will make a non-issue-closing magic word the default.